### PR TITLE
Development

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,9 +4,9 @@ todo.txt
 artifact
 dist
 bin
-vendor
 .git
 .DS_Store
 .distignore
 .gitignore
 phpcs.xml
+lpac.zip

--- a/.distignore-github-lite
+++ b/.distignore-github-lite
@@ -1,6 +1,6 @@
 todo.txt
-vendor
-.DS_Store
-dist
 artifact
+dist
+.git
+.DS_Store
 lpac.zip

--- a/bin/freemius-prep.sh
+++ b/bin/freemius-prep.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Start fresh
+rm -rf dist
+rm -rf artifact
+rm lpac.zip
+
+# Make our directories
+mkdir -p dist
+mkdir -p artifact
+
+# Remove dev dependencies
+composer install --no-dev
+
+# Sync SVN
+# rsync -acvP --delete --exclude-from=".distignore" ./ "$LPAC_SVN"
+
+# Sync dist folder
+rsync -acvP --delete --exclude-from=".distignore" ./ "./dist"
+
+#Change to our dist folder and zip to artifact folder
+(cd dist && zip -r ../artifact/lpac.zip .)
+
+# Re-add dev dependencies
+composer install
+

--- a/bin/github-lite-prep.sh
+++ b/bin/github-lite-prep.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Prepare lite version of plugin for uploading to github.
+
+# Start fresh
+rm -rf dist
+rm -rf artifact
+rm lpac.zip
+
+# Make our directories
+mkdir -p dist
+mkdir -p artifact
+
+# Remove dev dependencies
+composer install --no-dev
+
+# Sync dist folder
+rsync -acvP --delete --exclude-from=".distignore-github-lite" ./ "./dist"
+
+#Change to our dist folder and zip to artifact folder
+(cd dist && zip -r ../artifact/lpac.zip .)
+
+# Re-add dev dependencies
+composer install
+

--- a/bin/svn-sync.sh
+++ b/bin/svn-sync.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-mkdir -p "dist"
-mkdir -p "artifact"
-
-rsync -acvP --delete --exclude-from=".distignore" ./ "$LPAC_SVN"

--- a/class-lpac-uninstall.php
+++ b/class-lpac-uninstall.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Fired when the plugin is uninstalled.
+ *
+ * When populating this file, consider the following flow
+ * of control:
+ *
+ * - This method should be static
+ * - Check if the $_REQUEST content actually is the plugin name
+ * - Run an admin referrer check to make sure it goes through authentication
+ * - Verify the output of $_GET makes sense
+ * - Repeat with other user roles. Best directly by using the links/query string parameters.
+ * - Repeat things for multisite. Once for a single site in the network, once sitewide.
+ *
+ *
+ * For more information, see the following discussion:
+ * https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/pull/123#issuecomment-28541913
+ *
+ * @link       https://uriahsvictor.com
+ * @since      1.0.0
+ *
+ * @package    Lpac
+ */
+
+class Lpac_Uninstall {
+
+	/**
+	 * Remove plugin settings.
+	 *
+	 * @since    1.0.0
+	 * @since    1.1.0 Turned into class to support freemius.
+	*/
+	public static function remove_plugin_settings() {
+
+		$should_delete_settings = get_option( 'lpac_delete_settings_on_uninstall' );
+
+		if ( $should_delete_settings !== 'yes' ) {
+			return;
+		}
+
+		$option_keys = array(
+			'lpac_enabled',
+			'lpac_google_maps_api_key',
+			'lpac_map_starting_coordinates',
+			'lpac_general_map_zoom_level',
+			'lpac_allow_clicking_on_map_icons',
+			'lpac_map_background_color',
+			'lpac_checkout_map_orientation',
+			'lpac_checkout_page_map_height',
+			'lpac_checkout_page_map_width',
+			'lpac_display_map_on_order_received_page',
+			'lpac_order_received_page_map_height',
+			'lpac_order_received_page_map_width',
+			'lpac_display_map_on_view_order_page',
+			'lpac_view_order_page_map_height',
+			'lpac_view_order_page_map_width',
+			'lpac_order_received_page_map_id',
+			'lpac_view_order_page_map_id',
+			'lpac_checkout_page_map_id',
+			'lpac_autofill_billing_fields',
+			'lpac_email_delivery_map_emails',
+			'lpac_email_delivery_map_link_location',
+			'lpac_email_delivery_map_link_type',
+			'lpac_enable_delivery_map_link_in_email',
+			'lpac_delete_settings_on_uninstall',
+		);
+
+		foreach ( $option_keys as $key ) {
+			delete_option( $key );
+		}
+
+		$lpac_qr_codes_directory = wp_upload_dir()['basedir'] . '/' . 'lpac-qr-codes';
+
+		( new WP_Filesystem_Direct( '' ) )->delete( $lpac_qr_codes_directory, true, 'd' );
+
+	}
+
+}

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,16 @@
 {   
     "scripts": {
         "lint" : "vendor/bin/phpcs",
-        "beautify": "vendor/bin/phpcbf",
-        "svn-sync": "sh bin/svn-sync.sh"
+        "beautify": "vendor/bin/phpcbf -p",
+        "dist": "sh bin/freemius-prep.sh",
+        "github-lite": "sh bin/github-lite-prep.sh"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "wp-coding-standards/wpcs": "^2.3"
+    },
+    "require": {
+        "freemius/wordpress-sdk": "^2.4",
+        "endroid/qr-code": "^4.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,204 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a147d50695956de52f7cbf827b47830",
-    "packages": [],
+    "content-hash": "3dba8734a6540053cf2ecb760db7ef69",
+    "packages": [
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "f73543ac4e1def05f1a70bcd1525c8a157a1ad09"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/f73543ac4e1def05f1a70bcd1525c8a157a1ad09",
+                "reference": "f73543ac4e1def05f1a70bcd1525c8a157a1ad09",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^1.4",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "time": "2021-06-18T13:26:35+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "5abf82f213618696dda8e3bf6f64dd042d8542b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/5abf82f213618696dda8e3bf6f64dd042d8542b2",
+                "reference": "5abf82f213618696dda8e3bf6f64dd042d8542b2",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "time": "2020-10-02T16:03:48+00:00"
+        },
+        {
+            "name": "endroid/qr-code",
+            "version": "4.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/endroid/qr-code.git",
+                "reference": "f38ff0d968788aef0ddefb957062024b4ea521e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/f38ff0d968788aef0ddefb957062024b4ea521e1",
+                "reference": "f38ff0d968788aef0ddefb957062024b4ea521e1",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^2.0",
+                "php": "^7.3||^8.0"
+            },
+            "require-dev": {
+                "endroid/quality": "dev-master",
+                "ext-gd": "*",
+                "khanamiryan/qrcode-detector-decoder": "^1.0.4",
+                "setasign/fpdf": "^1.8.2"
+            },
+            "suggest": {
+                "ext-gd": "Enables you to write PNG images",
+                "khanamiryan/qrcode-detector-decoder": "Enables you to use the image validator",
+                "roave/security-advisories": "Makes sure package versions with known security issues are not installed",
+                "setasign/fpdf": "Enables you to use the PDF writer"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Endroid\\QrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeroen van den Enden",
+                    "email": "info@endroid.nl"
+                }
+            ],
+            "description": "Endroid QR Code",
+            "homepage": "https://github.com/endroid/qr-code",
+            "keywords": [
+                "code",
+                "endroid",
+                "php",
+                "qr",
+                "qrcode"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/endroid",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-05-08T14:30:54+00:00"
+        },
+        {
+            "name": "freemius/wordpress-sdk",
+            "version": "2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Freemius/wordpress-sdk.git",
+                "reference": "84a9be4717effd7697a217e0d931f48ae0d2ecc6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Freemius/wordpress-sdk/zipball/84a9be4717effd7697a217e0d931f48ae0d2ecc6",
+                "reference": "84a9be4717effd7697a217e0d931f48ae0d2ecc6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-only"
+            ],
+            "description": "Freemius WordPress SDK",
+            "homepage": "https://freemius.com",
+            "keywords": [
+                "freemius",
+                "plugin",
+                "sdk",
+                "theme",
+                "wordpress",
+                "wordpress-plugin",
+                "wordpress-theme"
+            ],
+            "time": "2021-02-08T16:47:44+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/includes/admin/class-lpac-admin-display.php
+++ b/includes/admin/class-lpac-admin-display.php
@@ -13,7 +13,6 @@
  */
 class Lpac_Admin_Display {
 
-
 	/**
 	 * Displays the view on map button on the admin order page.
 	 *

--- a/includes/admin/class-lpac-admin-notices.php
+++ b/includes/admin/class-lpac-admin-notices.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+* Admin Notices.
+*
+* Houses all the notices to show in admin dashboard.
+*
+* @link    https://uriahsvictor.com
+* @since    1.1.0
+*
+* @package    Lpac
+* @subpackage Lpac/inludes/admin
+*/
+class Lpac_Admin_Notices {
+
+	/**
+	* Detect if WooCommerce is active.
+	*
+	* Plugin runs off WooCommerce so requires WooCommerce to be active.
+	*
+	* @since    1.1.0
+	*
+	*/
+	public function lpac_wc_not_active_notice() {
+
+		if ( ! class_exists( 'woocommerce' ) ) {
+			?>
+
+			  <div class="notice notice-error is-dismissible">
+				<?php echo sprintf( __( '%1$s%2$sLocation Picker at Checkout for WooCommerce(LPAC) NOTICE:%3$s WooCommerce is not activated, please activate it to use the plugin.%4$s', 'lpac' ), '<p>', '<b>', '</b>', '</p>' ); ?>
+			  </div>
+			  <?php
+
+		}
+
+	}
+
+	/**
+	* Detect if site has HTTPS support.
+	*
+	* Geolocation requires that site is running under HTTPS
+	* https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features
+	*
+	* @since    1.1.0
+	*
+	*/
+	public function lpac_site_not_https() {
+
+		if ( is_ssl() ) {
+			return;
+		}
+
+		if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ) {
+			return;
+		}
+
+		?>
+
+			  <div class="notice notice-error is-dismissible">
+				<?php echo sprintf( __( '%1$s%2$sLocation Picker at Checkout for WooCommerce(LPAC) NOTICE:%3$s HTTPS not detected on this website. The plugin will not work. Please enable HTTPS on this website.%4$s', 'lpac' ), '<p>', '<b>', '</b>', '</p>' ); ?>
+			  </div>
+			  <?php
+
+	}
+
+}

--- a/includes/admin/class-lpac-admin-settings.php
+++ b/includes/admin/class-lpac-admin-settings.php
@@ -10,232 +10,372 @@
  * @subpackage Lpac/admin
  * @author     Uriahs Victor <info@soaringleads.com>
  */
-class Lpac_Admin_Settings {
-
-	/**
-	 * Add settings section to WooCommerce settings page.
-	 *
-	 * @since    1.0.0
-	 * @param array $sections The sections array passed by WooCommerce.
-	 */
-	public function lpac_add_settings_section( $sections ) {
-
-		$sections['lpac_settings'] = __( 'Location Picker at Checkout', 'lpac' );
-		return $sections;
-
-	}
-
-	/**
-	 * Create the setting options for the plugin.
-	 *
-	 * @since    1.0.0
-	 * @param array $settings The WooCommerce settings.
-	 * @param array $current_section The current settings tab being viewed.
-	 */
-	public function lpac_plugin_settings( $settings, $current_section ) {
-
-		/**
-		 * Check if the current section is what we want
-		 **/
-		if ( $current_section == 'lpac_settings' ) {
-
-			$lpac_settings = array();
-
-			$lpac_settings[] = array(
-				'name' => __( 'LPAC Settings', 'lpac' ),
-				'id'   => 'lpac',
-				'type' => 'title',
-				'desc' => __( 'Use the below options to change the plugin settings.', 'lpac' ),
-			);
-
-			$lpac_settings[] = array(
-				'name'     => __( 'Google Maps API Key', 'lpac' ),
-				'desc_tip' => __( 'Enter the API key from Google cloud console.', 'lpac' ),
-				'desc'     => __( 'Enter the API you copied from the Google Cloud Console. <a href="https://github.com/UVLabs/location-picker-at-checkout-for-woocommerce/wiki/Getting-Your-API-Key" target="_blank">Learn More >></a>', 'lpac' ),
-				'id'       => 'lpac_google_maps_api_key',
-				'type'     => 'text',
-				'css'      => 'min-width:300px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'        => __( 'Default Coordinates', 'lpac' ),
-				'desc_tip'    => __( 'Enter the default latitude and logitude that will be fetched every time the map loads.', 'lpac' ),
-				'desc'        => __( 'Enter the default latitude and logitude that will be fetched every time the map loads. You can find the coordinates for a location <a href="https://www.latlong.net/" target="_blank">here >></a>. Be sure to include the comma when adding your coordinates above.', 'lpac' ),
-				'id'          => 'lpac_map_starting_coordinates',
-				'placeholder' => '14.024519,-60.974876',
-				'type'        => 'text',
-				'css'         => 'min-width:300px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'        => __( 'Default Zoom', 'lpac' ),
-				'desc_tip'    => __( 'Recommended number is 16.', 'lpac' ),
-				'desc'        => __( 'Enter the default zoom that will be used every time the map loads.', 'lpac' ),
-				'id'          => 'lpac_general_map_zoom_level',
-				'placeholder' => '16',
-				'default'     => 3,
-				'type'        => 'number',
-				'css'         => 'max-width:80px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'     => __( 'Enable Clickable Icons', 'lpac' ),
-				'desc_tip' => __( 'Should customers be able to click on icons of different locations that appear on Google Maps? Recommended setting: Disabled', 'lpac' ),
-				'desc'     => __( 'Yes', 'lpac' ),
-				'id'       => 'lpac_allow_clicking_on_map_icons',
-				'type'     => 'checkbox',
-				'css'      => 'min-width:300px;',
-			);
-
-			// TODO default checkbox
-			// https://wordpress.stackexchange.com/questions/390270/woocommerce-settings-api-set-checkbox-checked-by-default?noredirect=1#comment567330_390270
-			// $lpac_settings[] = array(
-			// 	'name'     => __( 'test', 'lpac' ),
-			// 	// 'cbvalue' => 'yes',
-			// 	// 'value' => 'yes',
-			// 	'desc_tip' => __( 'Should customers be able to click on icons of different locations that appear on Google Maps? Recommended setting: Disabled', 'lpac' ),
-			// 	'desc'     => __( 'Yes', 'lpac' ),
-			// 	'id'       => 'lpac_test_option',
-			// 	'type'     => 'checkbox',
-			// 	'css'      => 'min-width:300px;',
-			// );
-
-			// TODO
-			// $lpac_settings[] = array(
-			// 	'name'     => __( 'Remove Map Buttons', 'lpac' ),
-			//     'desc'     => __( 'This will remove all interative buttons from the map such as Zoom and Terrain chooser.', 'lpac' ),
-			// 	'id'       => 'lpac_hide_map_buttons',
-			// 	'type'     => 'checkbox',
-			// 	'css'      => 'min-width:300px;',
-			// );
-
-			$lpac_settings[] = array(
-				'name'        => __( 'Background Color (HEX)', 'lpac' ),
-				'desc'        => __( 'Background color of map container (visible while map is loading).', 'lpac' ),
-				'id'          => 'lpac_map_background_color',
-				'type'        => 'text',
-				'placeholder' => '#EEEEEE',
-				'default'     => '#EEEEEE',
-				'css'         => 'max-width:80px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'     => __( 'Where Should the Map Appear on the Checkout Page?', 'lpac' ),
-				'desc_tip' => __( 'This option displays a map view on the order received page after an order has been placed by a customer.', 'lpac' ),
-				'id'       => 'lpac_checkout_map_orientation',
-				'type'     => 'select',
-				'options'  => array(
-					'shipping_address_area_top'    => __( 'Shipping Address Area - Top', 'lpac' ),
-					'shipping_address_area_bottom' => __( 'Shipping Address Area - Bottom (recommended)', 'lpac' ),
-					'billing_address_area_top'     => __( 'Billing Address Area - Top', 'lpac' ),
-					'billing_address_area_bottom'  => __( 'Billing Address Area - Bottom', 'lpac' ),
-				),
-				'css'      => 'min-width:300px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'     => __( 'Autofill Billing fields', 'lpac' ),
-				'desc_tip' => __( 'Should the billing fields be automatically populated with information pulled from the location?', 'lpac' ),
-				'desc'     => __( 'Yes', 'lpac' ),
-				'id'       => 'lpac_autofill_billing_fields',
-				'type'     => 'checkbox',
-				'css'      => 'min-width:300px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'        => __( 'Checkout Page Map Height (in px)', 'lpac' ),
-				'desc_tip'    => __( 'Enter the height of map you\'d like.', 'lpac' ),
-				'id'          => 'lpac_checkout_page_map_height',
-				'placeholder' => '400',
-				'default'     => 400,
-				'type'        => 'number',
-				'css'         => 'max-width:80px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'        => __( 'Checkout Page Map Width (in %)', 'lpac' ),
-				'desc_tip'    => __( 'Enter the width of map you\'d like.', 'lpac' ),
-				'id'          => 'lpac_checkout_page_map_width',
-				'placeholder' => '100',
-				'default'     => 100,
-				'type'        => 'number',
-				'css'         => 'max-width:80px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'     => __( 'Show Map on the Order Received Page', 'lpac' ),
-				'desc_tip' => __( 'This option displays a map view on the order received page after an order has been placed by a customer.', 'lpac' ),
-				'id'       => 'lpac_display_map_on_order_received_page',
-				'type'     => 'checkbox',
-				'css'      => 'min-width:300px;',
-				'desc'     => __( 'Enable', 'lpac' ),
-			);
-
-			$lpac_settings[] = array(
-				'name'        => __( 'Order Received Page Map Height (in px)', 'lpac' ),
-				'desc_tip'    => __( 'Enter the height of map you\'d like.', 'lpac' ),
-				'id'          => 'lpac_order_received_page_map_height',
-				'placeholder' => '400',
-				'default'     => 400,
-				'type'        => 'number',
-				'css'         => 'max-width:80px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'        => __( 'Order Received Page Map Width (in px)', 'lpac' ),
-				'desc_tip'    => __( 'Enter the width of map you\'d like.', 'lpac' ),
-				'id'          => 'lpac_order_received_page_map_width',
-				'placeholder' => '100',
-				'default'     => 100,
-				'type'        => 'number',
-				'css'         => 'max-width:80px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'     => __( 'Show Map on View Order Page', 'lpac' ),
-				'desc_tip' => __( 'This option displays a map view on the order details page in the customer account.', 'lpac' ),
-				'id'       => 'lpac_display_map_on_view_order_page',
-				'type'     => 'checkbox',
-				'css'      => 'min-width:300px;',
-				'desc'     => __( 'Enable', 'lpac' ),
-			);
-
-			$lpac_settings[] = array(
-				'name'        => __( 'View Order Page Map Height (in px)', 'lpac' ),
-				'desc_tip'    => __( 'Enter the height of map you\'d like.', 'lpac' ),
-				'id'          => 'lpac_view_order_page_map_height',
-				'placeholder' => '400',
-				'default'     => 400,
-				'type'        => 'number',
-				'css'         => 'max-width:80px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'        => __( 'View Order Page Map Width (in px)', 'lpac' ),
-				'desc_tip'    => __( 'Enter the height of map you\'d like.', 'lpac' ),
-				'id'          => 'lpac_view_order_page_map_width',
-				'placeholder' => '100',
-				'default'     => 100,
-				'type'        => 'number',
-				'css'         => 'max-width:80px;',
-			);
-
-			$lpac_settings[] = array(
-				'name'     => __( 'Housekeeping', 'lpac' ),
-				'desc_tip' => __( 'Delete all plugin settings on uninstall.', 'lpac' ),
-				'id'       => 'lpac_delete_settings_on_uninstall',
-				'type'     => 'checkbox',
-			);
-
-			$lpac_settings[] = array(
-				'type' => 'sectionend',
-				'id'   => 'lpac',
-			);
-
-			return $lpac_settings;
-
-		}
-
-	}
+class Lpac_Admin_Settings extends WC_Settings_Page
+{
+    /**
+     * Setting page id.
+     *
+     * @var string
+     */
+    protected  $id ;
+    /**
+     * Setting page label.
+     *
+     * @var string
+     */
+    protected  $label ;
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->id = 'lpac_settings';
+        $this->label = __( 'Location Picker at Checkout', 'lpac' );
+        /**
+         *  Define all hooks instead of inheriting from parent
+         */
+        // parent::__construct();
+        // Add the tab to the tabs array
+        // This method is located in parent class
+        add_filter( 'woocommerce_settings_tabs_array', array( $this, 'add_settings_page' ), 99 );
+        // Add sections to our custom tab
+        add_action( 'woocommerce_sections_' . $this->id, array( $this, 'lpac_output_settings_sections' ) );
+        // Output our different settings
+        add_action( 'woocommerce_settings_' . $this->id, array( $this, 'lpac_output_plugin_settings' ) );
+        // Save our settings
+        add_action( 'woocommerce_settings_save_' . $this->id, array( $this, 'lpac_save_plugin_settings' ) );
+    }
+    
+    /**
+     * Create plugin settings sections.
+     *
+     * @return array $sections The sections for the custom tab.
+     * @since    1.1.0
+     */
+    public function lpac_create_plugin_settings_sections()
+    {
+        $sections = array(
+            ''        => __( 'General', 'lpac' ),
+            'premium' => __( 'Premium', 'lpac' ),
+        );
+        // TODO: Allow this section once development of premium features are futher ahead.
+        if ( lpac_fs()->is_free_plan() ) {
+            unset( $sections['premium'] );
+        }
+        return apply_filters( 'woocommerce_get_sections_' . LPAC_PLUGIN_NAME, $sections );
+    }
+    
+    /**
+     * Output the settings sections markup.
+     *
+     * @since    1.1.0
+     */
+    public function lpac_output_settings_sections()
+    {
+        global  $current_section ;
+        $sections = $this->lpac_create_plugin_settings_sections();
+        if ( empty($sections) || 1 === sizeof( $sections ) ) {
+            return;
+        }
+        echo  '<ul class="subsubsub">' ;
+        $array_keys = array_keys( $sections );
+        foreach ( $sections as $id => $label ) {
+            echo  '<li><a href="' . admin_url( 'admin.php?page=wc-settings&tab=' . $this->id . '&section=' . sanitize_title( $id ) ) . '" class="' . (( $current_section == $id ? 'current' : '' )) . '">' . $label . '</a> ' . (( end( $array_keys ) == $id ? '' : '|' )) . ' </li>' ;
+        }
+        echo  '</ul><br class="clear" />' ;
+    }
+    
+    /**
+     * Create the setting options for the plugin.
+     *
+     * @since    1.0.0
+     * @param array $settings The WooCommerce settings.
+     * @param array $current_section The current settings tab being viewed.
+     */
+    public function lpac_create_plugin_settings_fields()
+    {
+        global  $current_section ;
+        $lpac_settings = array();
+        // The default tab("General") has no section id, if it does then it's not the General tab
+        // And its most likely the "Premium tab"
+        
+        if ( empty($current_section) ) {
+            $lpac_settings[] = array(
+                'name' => __( 'LPAC General Settings', 'lpac' ),
+                'id'   => 'lpac',
+                'type' => 'title',
+                'desc' => __( 'Use the below options to change the general plugin settings.', 'lpac' ),
+            );
+            $plugin_enabled = get_option( 'lpac_enabled' );
+            /*
+             * If the option doesn't exist then this is most likely a new install, so set the checkbox to checked by default.
+             * If the option already exists, then use the setting saved in the database.
+             */
+            
+            if ( empty($plugin_enabled) ) {
+                $lpac_settings[] = array(
+                    'name'     => __( 'Enabled', 'lpac' ),
+                    'desc'     => __( 'Yes', 'lpac' ),
+                    'desc_tip' => __( 'Enable map on checkout and order details pages.', 'lpac' ),
+                    'id'       => 'lpac_enabled',
+                    'type'     => 'checkbox',
+                    'css'      => 'max-width:80px;',
+                    'value'    => 'yes',
+                );
+            } else {
+                $lpac_settings[] = array(
+                    'name'     => __( 'Enabled', 'lpac' ),
+                    'desc'     => __( 'Yes', 'lpac' ),
+                    'desc_tip' => __( 'Enable map on checkout and order details pages.', 'lpac' ),
+                    'id'       => 'lpac_enabled',
+                    'type'     => 'checkbox',
+                    'css'      => 'max-width:80px;',
+                );
+            }
+            
+            $lpac_settings[] = array(
+                'name'     => __( 'Google Maps API Key', 'lpac' ),
+                'desc_tip' => __( 'Enter the API key from Google cloud console.', 'lpac' ),
+                'desc'     => __( 'Enter the API you copied from the Google Cloud Console. <a href="https://github.com/UVLabs/location-picker-at-checkout-for-woocommerce/wiki/Getting-Your-API-Key" target="_blank">Learn More >></a>', 'lpac' ),
+                'id'       => 'lpac_google_maps_api_key',
+                'type'     => 'text',
+                'css'      => 'min-width:300px;',
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'Default Coordinates', 'lpac' ),
+                'desc_tip'    => __( 'Enter the default latitude and logitude that will be fetched every time the map loads.', 'lpac' ),
+                'desc'        => __( 'Enter the default latitude and logitude that will be fetched every time the map loads. You can find the coordinates for a location <a href="https://www.latlong.net/" target="_blank">here >></a>. Be sure to include the comma when adding your coordinates above.', 'lpac' ),
+                'id'          => 'lpac_map_starting_coordinates',
+                'placeholder' => '14.024519,-60.974876',
+                'type'        => 'text',
+                'css'         => 'min-width:300px;',
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'Default Zoom', 'lpac' ),
+                'desc_tip'    => __( 'Recommended number is 16.', 'lpac' ),
+                'desc'        => __( 'Enter the default zoom that will be used every time the map loads.', 'lpac' ),
+                'id'          => 'lpac_general_map_zoom_level',
+                'placeholder' => '16',
+                'default'     => 3,
+                'type'        => 'number',
+                'css'         => 'max-width:80px;',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Enable Clickable Icons', 'lpac' ),
+                'desc_tip' => __( 'Should customers be able to click on icons of different locations that appear on Google Maps? Recommended setting: Disabled', 'lpac' ),
+                'desc'     => __( 'Yes', 'lpac' ),
+                'id'       => 'lpac_allow_clicking_on_map_icons',
+                'type'     => 'checkbox',
+                'css'      => 'min-width:300px;',
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'Background Color (HEX)', 'lpac' ),
+                'desc'        => __( 'Background color of map container (visible while map is loading).', 'lpac' ),
+                'id'          => 'lpac_map_background_color',
+                'type'        => 'color',
+                'placeholder' => '#eeeeee',
+                'default'     => '#EEEEEE',
+                'css'         => 'max-width:80px;',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Where Should the Map Appear on the Checkout Page?', 'lpac' ),
+                'desc_tip' => __( 'This option displays a map view on the order received page after an order has been placed by a customer.', 'lpac' ),
+                'id'       => 'lpac_checkout_map_orientation',
+                'type'     => 'select',
+                'options'  => array(
+                'woocommerce_before_checkout_shipping_form' => __( 'Shipping Address Area - Top', 'lpac' ),
+                'woocommerce_after_checkout_shipping_form'  => __( 'Shipping Address Area - Bottom (recommended)', 'lpac' ),
+                'woocommerce_before_checkout_billing_form'  => __( 'Billing Address Area - Top', 'lpac' ),
+                'woocommerce_after_checkout_billing_form'   => __( 'Billing Address Area - Bottom', 'lpac' ),
+            ),
+                'css'      => 'min-width:300px;',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Autofill Billing fields', 'lpac' ),
+                'desc_tip' => __( 'Should the billing fields be automatically populated with information pulled from the location?', 'lpac' ),
+                'desc'     => __( 'Yes', 'lpac' ),
+                'id'       => 'lpac_autofill_billing_fields',
+                'type'     => 'checkbox',
+                'css'      => 'min-width:300px;',
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'Checkout Page Map Height (in px)', 'lpac' ),
+                'desc_tip'    => __( 'Enter the height of map you\'d like.', 'lpac' ),
+                'id'          => 'lpac_checkout_page_map_height',
+                'placeholder' => '400',
+                'default'     => 400,
+                'type'        => 'number',
+                'css'         => 'max-width:80px;',
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'Checkout Page Map Width (in %)', 'lpac' ),
+                'desc_tip'    => __( 'Enter the width of map you\'d like.', 'lpac' ),
+                'id'          => 'lpac_checkout_page_map_width',
+                'placeholder' => '100',
+                'default'     => 100,
+                'type'        => 'number',
+                'css'         => 'max-width:80px;',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Show Map on the Order Received Page', 'lpac' ),
+                'desc_tip' => __( 'This option displays a map view on the order received page after an order has been placed by a customer.', 'lpac' ),
+                'id'       => 'lpac_display_map_on_order_received_page',
+                'type'     => 'checkbox',
+                'css'      => 'min-width:300px;',
+                'desc'     => __( 'Enable', 'lpac' ),
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'Order Received Page Map Height (in px)', 'lpac' ),
+                'desc_tip'    => __( 'Enter the height of map you\'d like.', 'lpac' ),
+                'id'          => 'lpac_order_received_page_map_height',
+                'placeholder' => '400',
+                'default'     => 400,
+                'type'        => 'number',
+                'css'         => 'max-width:80px;',
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'Order Received Page Map Width (in px)', 'lpac' ),
+                'desc_tip'    => __( 'Enter the width of map you\'d like.', 'lpac' ),
+                'id'          => 'lpac_order_received_page_map_width',
+                'placeholder' => '100',
+                'default'     => 100,
+                'type'        => 'number',
+                'css'         => 'max-width:80px;',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Show Map on View Order Page', 'lpac' ),
+                'desc_tip' => __( 'This option displays a map view on the order details page in the customer account.', 'lpac' ),
+                'id'       => 'lpac_display_map_on_view_order_page',
+                'type'     => 'checkbox',
+                'css'      => 'min-width:300px;',
+                'desc'     => __( 'Enable', 'lpac' ),
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'View Order Page Map Height (in px)', 'lpac' ),
+                'desc_tip'    => __( 'Enter the height of map you\'d like.', 'lpac' ),
+                'id'          => 'lpac_view_order_page_map_height',
+                'placeholder' => '400',
+                'default'     => 400,
+                'type'        => 'number',
+                'css'         => 'max-width:80px;',
+            );
+            $lpac_settings[] = array(
+                'name'        => __( 'View Order Page Map Width (in px)', 'lpac' ),
+                'desc_tip'    => __( 'Enter the height of map you\'d like.', 'lpac' ),
+                'id'          => 'lpac_view_order_page_map_width',
+                'placeholder' => '100',
+                'default'     => 100,
+                'type'        => 'number',
+                'css'         => 'max-width:80px;',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Add Map Link to Order Emails?', 'lpac' ),
+                'desc_tip' => __( 'Add either a Button or QR Code that links to Google Maps to the order emails.', 'lpac' ),
+                'id'       => 'lpac_enable_delivery_map_link_in_email',
+                'desc'     => __( 'Yes', 'lpac' ),
+                'type'     => 'checkbox',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Link Type', 'lpac' ),
+                'desc_tip' => __( 'Add either a button to Google Maps or a QR Code to the order emails.', 'lpac' ),
+                'desc'     => __( 'QR Codes are saved to your uploads directory at: <code>/wp-content/uploads/lpac-qr-codes/year/month/day/order_id.jpg</code>', 'lpac' ),
+                'id'       => 'lpac_email_delivery_map_link_type',
+                'type'     => 'select',
+                'options'  => array(
+                'button'  => __( 'Button', 'lpac' ),
+                'qr_code' => __( 'QR Code', 'lpac' ),
+            ),
+                'css'      => 'min-width:300px;',
+            );
+            $lpac_settings[] = array(
+                'name'    => __( 'Link Location', 'lpac' ),
+                'id'      => 'lpac_email_delivery_map_link_location',
+                'type'    => 'select',
+                'options' => array(
+                'woocommerce_email_before_order_table' => __( 'Before Order Table', 'lpac' ),
+                'woocommerce_email_customer_details'   => __( 'Before Customer Details', 'lpac' ),
+            ),
+                'css'     => 'min-width:300px;',
+            );
+            $lpac_settings[] = array(
+                'name'    => __( 'Select Emails', 'lpac' ),
+                'class'   => 'select2',
+                'desc'    => __( 'Select the Emails you\'d like this setting to take effect on.', 'lpac' ),
+                'id'      => 'lpac_email_delivery_map_emails',
+                'type'    => 'multiselect',
+                'options' => array(
+                'new_order'                => __( 'New Order', 'lpac' ),
+                'customer_on_hold_order'   => __( 'Order on Hold', 'lpac' ),
+                'customer_note'            => __( 'Customer Note', 'lpac' ),
+                'customer_completed_order' => __( 'Completed Order', 'lpac' ),
+                'customer_invoice'         => __( 'Customer Invoice', 'lpac' ),
+            ),
+                'css'     => 'min-width:300px;height: 100px',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Housekeeping', 'lpac' ),
+                'desc_tip' => __( 'Delete all plugin settings on uninstall.', 'lpac' ),
+                'id'       => 'lpac_delete_settings_on_uninstall',
+                'type'     => 'checkbox',
+            );
+            // Custom attributes example
+            // https://woocommerce.github.io/code-reference/files/woocommerce-includes-admin-wc-meta-box-functions.html#source-view.146
+            // $lpac_settings[] = array(
+            // 	'name'     => __( 'Test', 'lpac' ),
+            // 	'desc_tip' => __( 'Delete all plugin settings on uninstall.', 'lpac' ),
+            // 	'id'       => 'lpac_delete_settings_on_uninstall',
+            // 	'type'     => 'text',
+            // 	'custom_attributes' => array(
+            // 		'disabled' => 'disabled',
+            // 	)
+            // );
+            // TODO default checkbox
+            // https://wordpress.stackexchange.com/questions/390270/woocommerce-settings-api-set-checkbox-checked-by-default?noredirect=1#comment567330_390270
+            // $lpac_settings[] = array(
+            // 	'name'     => __( 'test', 'lpac' ),
+            // 	// 'cbvalue' => 'yes',
+            // 	// 'value' => 'yes',
+            // 	'desc_tip' => __( 'Should customers be able to click on icons of different locations that appear on Google Maps? Recommended setting: Disabled', 'lpac' ),
+            // 	'desc'     => __( 'Yes', 'lpac' ),
+            // 	'id'       => 'lpac_test_option',
+            // 	'type'     => 'checkbox',
+            // 	'css'      => 'min-width:300px;',
+            // );
+            $lpac_settings[] = array(
+                'type' => 'sectionend',
+                'id'   => 'lpac_general_settings_section_end',
+            );
+        }
+        
+        if ( $current_section === 'premium' ) {
+        }
+        return apply_filters( 'woocommerce_get_settings_' . $this->id, $lpac_settings );
+    }
+    
+    /**
+     * Output the plugin's settings markup.
+     *
+     * @since    1.1.0
+     */
+    public function lpac_output_plugin_settings()
+    {
+        $settings = $this->lpac_create_plugin_settings_fields();
+        WC_Admin_Settings::output_fields( $settings );
+    }
+    
+    /**
+     *  Save our settings.
+     *
+     */
+    public function lpac_save_plugin_settings()
+    {
+        global  $current_section ;
+        $settings = $this->lpac_create_plugin_settings_fields();
+        WC_Admin_Settings::save_fields( $settings );
+        if ( $current_section ) {
+            do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
+        }
+    }
 
 }
+new Lpac_Admin_Settings();

--- a/includes/class-lpac.php
+++ b/includes/class-lpac.php
@@ -12,7 +12,6 @@
  * @package    Lpac
  * @subpackage Lpac/includes
  */
-
 /**
  * The core plugin class.
  *
@@ -27,254 +26,296 @@
  * @subpackage Lpac/includes
  * @author     Uriahs Victor <info@soaringleads.com>
  */
-class Lpac {
-
-	/**
-	 * The loader that's responsible for maintaining and registering all hooks that power
-	 * the plugin.
-	 *
-	 * @since    1.0.0
-	 * @access   protected
-	 * @var      Lpac_Loader    $loader    Maintains and registers all hooks for the plugin.
-	 */
-	protected $loader;
-
-	/**
-	 * The unique identifier of this plugin.
-	 *
-	 * @since    1.0.0
-	 * @access   protected
-	 * @var      string    $plugin_name    The string used to uniquely identify this plugin.
-	 */
-	protected $plugin_name;
-
-	/**
-	 * The current version of the plugin.
-	 *
-	 * @since    1.0.0
-	 * @access   protected
-	 * @var      string    $version    The current version of the plugin.
-	 */
-	protected $version;
-
-	/**
-	 * Define the core functionality of the plugin.
-	 *
-	 * Set the plugin name and the plugin version that can be used throughout the plugin.
-	 * Load the dependencies, define the locale, and set the hooks for the admin area and
-	 * the public-facing side of the site.
-	 *
-	 * @since    1.0.0
-	 */
-	public function __construct() {
-		if ( defined( 'LPAC_VERSION' ) ) {
-			$this->version = LPAC_VERSION;
-		} else {
-			$this->version = '1.0.0';
-		}
-		$this->plugin_name = 'lpac';
-
-		$this->load_dependencies();
-		$this->set_locale();
-		$this->define_admin_hooks();
-		$this->define_public_hooks();
-
-	}
-
-	/**
-	 * Load the required dependencies for this plugin.
-	 *
-	 * Include the following files that make up the plugin:
-	 *
-	 * - Lpac_Loader. Orchestrates the hooks of the plugin.
-	 * - Lpac_i18n. Defines internationalization functionality.
-	 * - Lpac_Admin. Defines all hooks for the admin area.
-	 * - Lpac_Public. Defines all hooks for the public side of the site.
-	 *
-	 * Create an instance of the loader which will be used to register the hooks
-	 * with WordPress.
-	 *
-	 * @since    1.0.0
-	 * @access   private
-	 */
-	private function load_dependencies() {
-
-		/**
-		 * The class responsible for orchestrating the actions and filters of the
-		 * core plugin.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-lpac-loader.php';
-
-		/**
-		 * The class responsible for defining internationalization functionality
-		 * of the plugin.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-lpac-i18n.php';
-
-		/**
-		 * The class responsible for defining all settings of the plugin.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/admin/class-lpac-admin-settings.php';
-
-		/**
-		 * The class responsible for defining all actions that occur in the admin area.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/admin/class-lpac-admin.php';
-
-		/**
-		 * The class responsible for defining all actions that occur in the admin-facing
-		 * side of the site.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/admin/class-lpac-admin-display.php';
-
-		/**
-		 * The class responsible for defining static helper functions that might
-		 * be used in multiple classes.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/helpers/class-lpac-functions-helper.php';
-
-		/**
-		 * The class responsible for defining all actions that occur in the public-facing
-		 * side of the site.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/public/class-lpac-public.php';
-
-		/**
-		 * The class responsible for defining all actions that occur in the public-facing
-		 * side of the site.
-		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/public/class-lpac-public-display.php';
-
-		$this->loader = new Lpac_Loader();
-
-	}
-
-	/**
-	 * Define the locale for this plugin for internationalization.
-	 *
-	 * Uses the Lpac_i18n class in order to set the domain and to register the hook
-	 * with WordPress.
-	 *
-	 * @since    1.0.0
-	 * @access   private
-	 */
-	private function set_locale() {
-
-		$plugin_i18n = new Lpac_i18n();
-
-		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
-
-	}
-
-	/**
-	 * Register all of the hooks related to the admin area functionality
-	 * of the plugin.
-	 *
-	 * @since    1.0.0
-	 * @access   private
-	 */
-	private function define_admin_hooks() {
-
-		$plugin_admin          = new Lpac_Admin( $this->get_plugin_name(), $this->get_version() );
-		$plugin_admin_display  = new Lpac_Admin_Display();
-		$plugin_admin_settings = new Lpac_Admin_Settings();
-
-		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
-		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
-		// Display map on order details page
-		$this->loader->add_action( 'woocommerce_admin_order_data_after_shipping_address', $plugin_admin_display, 'lpac_display_lpac_admin_order_meta', 10, 1 );
-
-		// WooCommerce
-		$this->loader->add_filter( 'woocommerce_get_sections_shipping', $plugin_admin_settings, 'lpac_add_settings_section', 10, 1 );
-		$this->loader->add_filter( 'woocommerce_get_settings_shipping', $plugin_admin_settings, 'lpac_plugin_settings', 10, 2 );
-
-	}
-
-	/**
-	 * Register all of the hooks related to the public-facing functionality
-	 * of the plugin.
-	 *
-	 * @since    1.0.0
-	 * @access   private
-	 */
-	private function define_public_hooks() {
-
-		$plugin_public         = new Lpac_Public( $this->get_plugin_name(), $this->get_version() );
-		$plugin_public_display = new Lpac_Public_Display();
-
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
-		$this->loader->add_action( 'wp_head', $plugin_public_display, 'lpac_output_map_custom_styles' );
-
-		// WooCommerce
-
-		$location = get_option( 'lpac_checkout_map_orientation', 'shipping_address_area_bottom' );
-
-		switch ( $location ) {
-			case 'billing_address_area_top':
-				$location = 'woocommerce_before_checkout_billing_form';
-				break;
-			case 'billing_address_area_bottom':
-				$location = 'woocommerce_after_checkout_billing_form';
-				break;
-			case 'shipping_address_area_top':
-				$location = 'woocommerce_before_checkout_shipping_form';
-				break;
-			case 'shipping_address_area_bottom':
-				$location = 'woocommerce_after_checkout_shipping_form';
-				break;
-			default:
-				$location = 'woocommerce_after_checkout_shipping_form';
-				break;
-		}
-
-		$location = apply_filters( 'lpac_checkout_map_orientation', $location );
-
-		$this->loader->add_action( $location, $plugin_public_display, 'lpac_output_map_on_checkout_page' );
-		$this->loader->add_filter( 'woocommerce_checkout_fields', $plugin_public_display, 'lpac_long_and_lat_inputs' );
-		$this->loader->add_action( 'woocommerce_checkout_update_order_meta', $plugin_public_display, 'lpac_save_cords_order_meta' );
-		$this->loader->add_action( 'woocommerce_order_details_after_order_table', $plugin_public_display, 'lpac_output_map_on_order_details_page' );
-
-	}
-
-	/**
-	 * Run the loader to execute all of the hooks with WordPress.
-	 *
-	 * @since    1.0.0
-	 */
-	public function run() {
-		$this->loader->run();
-	}
-
-	/**
-	 * The name of the plugin used to uniquely identify it within the context of
-	 * WordPress and to define internationalization functionality.
-	 *
-	 * @since     1.0.0
-	 * @return    string    The name of the plugin.
-	 */
-	public function get_plugin_name() {
-		return $this->plugin_name;
-	}
-
-	/**
-	 * The reference to the class that orchestrates the hooks with the plugin.
-	 *
-	 * @since     1.0.0
-	 * @return    Lpac_Loader    Orchestrates the hooks of the plugin.
-	 */
-	public function get_loader() {
-		return $this->loader;
-	}
-
-	/**
-	 * Retrieve the version number of the plugin.
-	 *
-	 * @since     1.0.0
-	 * @return    string    The version number of the plugin.
-	 */
-	public function get_version() {
-		return $this->version;
-	}
+class Lpac
+{
+    /**
+     * The loader that's responsible for maintaining and registering all hooks that power
+     * the plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      Lpac_Loader    $loader    Maintains and registers all hooks for the plugin.
+     */
+    protected  $loader ;
+    /**
+     * The unique identifier of this plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      string    $plugin_name    The string used to uniquely identify this plugin.
+     */
+    protected  $plugin_name ;
+    /**
+     * The current version of the plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      string    $version    The current version of the plugin.
+     */
+    protected  $version ;
+    /**
+     * Define the core functionality of the plugin.
+     *
+     * Set the plugin name and the plugin version that can be used throughout the plugin.
+     * Load the dependencies, define the locale, and set the hooks for the admin area and
+     * the public-facing side of the site.
+     *
+     * @since    1.0.0
+     */
+    public function __construct()
+    {
+        
+        if ( defined( 'LPAC_VERSION' ) ) {
+            $this->version = LPAC_VERSION;
+        } else {
+            $this->version = '1.0.0';
+        }
+        
+        $this->plugin_name = 'lpac';
+        $this->load_dependencies();
+        $this->set_locale();
+        $this->define_admin_hooks();
+        $this->define_public_hooks();
+    }
+    
+    /**
+     * Load the required dependencies for this plugin.
+     *
+     * Include the following files that make up the plugin:
+     *
+     * - Lpac_Loader. Orchestrates the hooks of the plugin.
+     * - Lpac_i18n. Defines internationalization functionality.
+     * - Lpac_Admin. Defines all hooks for the admin area.
+     * - Lpac_Public. Defines all hooks for the public side of the site.
+     *
+     * Create an instance of the loader which will be used to register the hooks
+     * with WordPress.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function load_dependencies()
+    {
+        /**
+         * The class responsible for orchestrating the actions and filters of the
+         * core plugin.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-lpac-loader.php';
+        /**
+         * The class responsible for defining internationalization functionality
+         * of the plugin.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-lpac-i18n.php';
+        /**
+         * The class responsible for defining all actions that occur in the admin area.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/admin/class-lpac-admin.php';
+        /**
+         * The class responsible for defining all actions that occur in the admin-facing
+         * side of the site.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/admin/class-lpac-admin-display.php';
+        /**
+         * The class responsible for all admin-facing notices
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/admin/class-lpac-admin-notices.php';
+        /**
+         * The class responsible for defining static helper functions that might
+         * be used in multiple classes.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/helpers/class-lpac-functions-helper.php';
+        /**
+         * The class responsible for defining all actions that occur in the public-facing
+         * side of the site.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/public/class-lpac-public.php';
+        /**
+         * The class responsible for defining all actions that occur in the public-facing
+         * side of the site.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/public/class-lpac-public-display.php';
+        /**
+         * The class responsible for generating QR Code using provided data.
+         *
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/public/class-lpac-qr-code-generator.php';
+        $this->loader = new Lpac_Loader();
+    }
+    
+    /**
+     * Define the locale for this plugin for internationalization.
+     *
+     * Uses the Lpac_i18n class in order to set the domain and to register the hook
+     * with WordPress.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function set_locale()
+    {
+        $plugin_i18n = new Lpac_i18n();
+        $this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+    }
+    
+    /**
+     * Register all of the hooks related to the admin area functionality
+     * of the plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function define_admin_hooks()
+    {
+        $plugin_admin = new Lpac_Admin( $this->get_plugin_name(), $this->get_version() );
+        $plugin_admin_display = new Lpac_Admin_Display();
+        $admin_notices = new Lpac_Admin_Notices();
+        $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+        $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+        // Notices
+        $this->loader->add_action( 'admin_notices', $admin_notices, 'lpac_wc_not_active_notice' );
+        $this->loader->add_action( 'admin_notices', $admin_notices, 'lpac_site_not_https' );
+        // Display map on order details page
+        $this->loader->add_action(
+            'woocommerce_admin_order_data_after_shipping_address',
+            $plugin_admin_display,
+            'lpac_display_lpac_admin_order_meta',
+            10,
+            1
+        );
+    }
+    
+    /**
+     * Register all of the hooks related to the public-facing functionality
+     * of the plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function define_public_hooks()
+    {
+        $plugin_public = new Lpac_Public( $this->get_plugin_name(), $this->get_version() );
+        $plugin_public_display = new Lpac_Public_Display();
+        $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
+        $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+        /*
+         * WooCommerce
+         */
+        $plugin_enabled = get_option( 'lpac_enabled', 'yes' );
+        if ( $plugin_enabled === 'no' ) {
+            return;
+        }
+        $this->loader->add_action( 'wp_head', $plugin_public_display, 'lpac_output_map_custom_styles' );
+        $checkout_page_map_location = get_option( 'lpac_checkout_map_orientation', 'woocommerce_after_checkout_shipping_form' );
+        /*
+         *	Update old options.
+         */
+        //TODO Delete this block when confident most users have updated.
+        
+        if ( $checkout_page_map_location === 'billing_address_area_top' ) {
+            $checkout_page_map_location = 'woocommerce_before_checkout_billing_form';
+            update_option( 'lpac_checkout_map_orientation', 'woocommerce_before_checkout_billing_form' );
+        } elseif ( $checkout_page_map_location === 'billing_address_area_bottom' ) {
+            $checkout_page_map_location = 'woocommerce_after_checkout_billing_form';
+            update_option( 'lpac_checkout_map_orientation', 'woocommerce_after_checkout_billing_form' );
+        } elseif ( $checkout_page_map_location === 'shipping_address_area_top' ) {
+            $checkout_page_map_location = 'woocommerce_before_checkout_shipping_form';
+            update_option( 'lpac_checkout_map_orientation', 'woocommerce_before_checkout_shipping_form' );
+        } elseif ( $checkout_page_map_location === 'shipping_address_area_bottom' ) {
+            $checkout_page_map_location = 'woocommerce_after_checkout_shipping_form';
+            update_option( 'lpac_checkout_map_orientation', 'woocommerce_after_checkout_shipping_form' );
+        }
+        
+        /*
+         * Output hidden input fields for latitude and longitude.
+         */
+        $this->loader->add_filter( 'woocommerce_checkout_fields', $plugin_public_display, 'lpac_create_lat_and_long_inputs' );
+        /*
+         * Output map on checkout page
+         */
+        $checkout_page_map_location = apply_filters( 'lpac_checkout_map_orientation', $checkout_page_map_location );
+        $this->loader->add_action( $checkout_page_map_location, $plugin_public_display, 'lpac_output_map_on_checkout_page' );
+        /*
+         * Output map on order received and order details pages.
+         */
+        $this->loader->add_action( 'woocommerce_order_details_after_order_table', $plugin_public_display, 'lpac_output_map_on_order_details_page' );
+        /*
+         * Save location coordinates with to order meta.
+         */
+        $this->loader->add_action( 'woocommerce_checkout_update_order_meta', $plugin_public_display, 'lpac_save_cords_order_meta' );
+        /*
+         * Validate latitude and longitude fields.
+         */
+        $validate_lat_long_fields = apply_filters( 'validate_lat_long_fields', true );
+        if ( $validate_lat_long_fields ) {
+            $this->loader->add_action(
+                'woocommerce_after_checkout_validation',
+                $plugin_public_display,
+                'lpac_validate_location_fields',
+                10,
+                2
+            );
+        }
+        /*
+         * Display map button link or qr code link in email.
+         */
+        $enable_map_link_in_email = get_option( 'lpac_enable_delivery_map_link_in_email' );
+        
+        if ( $enable_map_link_in_email === 'yes' ) {
+            $email_map_link_location = get_option( 'lpac_email_delivery_map_link_location' );
+            $email_map_link_location = apply_filters( 'lpac_email_delivery_map_link_location', $email_map_link_location );
+            $this->loader->add_action(
+                $email_map_link_location,
+                $plugin_public_display,
+                'lpac_add_delivery_location_link_to_email',
+                20,
+                4
+            );
+        }
+    
+    }
+    
+    /**
+     * Run the loader to execute all of the hooks with WordPress.
+     *
+     * @since    1.0.0
+     */
+    public function run()
+    {
+        $this->loader->run();
+    }
+    
+    /**
+     * The name of the plugin used to uniquely identify it within the context of
+     * WordPress and to define internationalization functionality.
+     *
+     * @since     1.0.0
+     * @return    string    The name of the plugin.
+     */
+    public function get_plugin_name()
+    {
+        return $this->plugin_name;
+    }
+    
+    /**
+     * The reference to the class that orchestrates the hooks with the plugin.
+     *
+     * @since     1.0.0
+     * @return    Lpac_Loader    Orchestrates the hooks of the plugin.
+     */
+    public function get_loader()
+    {
+        return $this->loader;
+    }
+    
+    /**
+     * Retrieve the version number of the plugin.
+     *
+     * @since     1.0.0
+     * @return    string    The version number of the plugin.
+     */
+    public function get_version()
+    {
+        return $this->version;
+    }
 
 }

--- a/includes/helpers/class-lpac-functions-helper.php
+++ b/includes/helpers/class-lpac-functions-helper.php
@@ -29,4 +29,20 @@ class Lpac_Functions_Helper {
 
 	}
 
+	/**
+	 * Create QR Code directory string based on the basedir or baseurl.
+	 *
+	 * @return string The qr code resource server path or url path
+	 * @since    1.1.0
+	 */
+	public static function lpac_get_qr_codes_directory( $base ) {
+
+		$qr_code_resource_base = wp_upload_dir()[ $base ];
+
+		$qr_code_resource_locator = $qr_code_resource_base . '/' . 'lpac-qr-codes' . '/' . date( 'Y' ) . '/' . date( 'm' ) . '/' . date( 'd' ) . '/';
+
+		return $qr_code_resource_locator;
+
+	}
+
 }

--- a/includes/public/class-lpac-public.php
+++ b/includes/public/class-lpac-public.php
@@ -74,9 +74,9 @@ class Lpac_Public {
 	 * @param      string    $plugin_name       The name of the plugin.
 	 * @param      string    $version    The version of this plugin.
 	 */
-	public function __construct( $plugin_name, $version ) {
-		$this->plugin_name = $plugin_name;
-		$this->version     = $version;
+	public function __construct() {
+		$this->plugin_name = LPAC_PLUGIN_NAME;
+		$this->version     = LPAC_VERSION;
 
 		$this->lpac_google_maps_link = 'https://maps.googleapis.com/maps/api/js?key=';
 		$this->lpac_google_api_key   = get_option( 'lpac_google_maps_api_key' );
@@ -210,17 +210,35 @@ class Lpac_Public {
 		$fill_in_billing_fields = apply_filters( 'lpac_autofill_billing_fields', $fill_in_billing_fields );
 
 		$data = array(
-			'lpac_map_default_latitude'  => $latitude,
-			'lpac_map_default_longitude' => $longitude,
-			'lpac_map_zoom_level'        => $zoom_level,
-			'lpac_map_clickable_icons'   => $clickable_icons === 'yes' ? true : false,
-			'lpac_map_background_color'  => $background_color,
-			'lpac_autofill_billing_fields'  => $fill_in_billing_fields  === 'yes' ? true : false,
+			'lpac_map_default_latitude'    => $latitude,
+			'lpac_map_default_longitude'   => $longitude,
+			'lpac_map_zoom_level'          => $zoom_level,
+			'lpac_map_clickable_icons'     => $clickable_icons === 'yes' ? true : false,
+			'lpac_map_background_color'    => $background_color,
+			'lpac_autofill_billing_fields' => $fill_in_billing_fields === 'yes' ? true : false,
 
 		);
 
 		return apply_filters( 'lpac_map_stored_settings', $data );
 
+	}
+
+	/**
+	* Detect needed Woocommerce pages.
+	*
+	* Detect if the page is one of which the map is supposed to show.
+	*
+	* @since    1.1.0
+	*
+	* @return bool Whether or not the page is one of our needed pages.
+	*/
+	public function lpac_is_allowed_woocommerce_pages() {
+
+		if ( is_wc_endpoint_url( 'view-order' ) || is_wc_endpoint_url( 'order-received' ) || is_checkout() ) {
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/includes/public/class-lpac-qr-code-generator.php
+++ b/includes/public/class-lpac-qr-code-generator.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Provide a admin area view for the plugin
+ *
+ * This file is used to markup the admin-facing aspects of the plugin.
+ *
+ * @link       https://uriahsvictor.com
+ * @since      1.1.0
+ *
+ * @package    Lpac
+ * @subpackage Lpac/public
+ */
+use Endroid\QrCode\Color\Color;
+use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelLow;
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Label\Label;
+use Endroid\QrCode\Logo\Logo;
+use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeModeMargin;
+use Endroid\QrCode\Writer\PngWriter;
+use Endroid\QrCode\Label\Font\NotoSans;
+
+class Lpac_Qr_Code_Generator {
+
+	/**
+	 * Creates a QR code
+	 *
+	 * @param int $options The options for the barcode such as its link and colors.
+	 * @param int $order_id The current order id.
+	 *
+	 * @since    1.1.0
+	 */
+	public static function lpac_generate_qr_code( $options, $order_id ) {
+
+		$path = self::lpac_qr_codes_directory();
+
+		if ( empty( $path ) ) {
+			error_log( 'Location Picker At Checkout for WooCommerce: QR Code directory path returned empty. See Lpac_Qr_Code_Generator::lpac_generate_qr_code()' );
+			return;
+		}
+
+		$path_with_filename = $path . $order_id . '.jpg';
+
+		$qr_code_data           = $options['qr_code_data'];
+		$qr_code_foreground_rgb = explode( ',', $options['qr_code_foreground_rgb'] );
+		$qr_code_background_rgb = explode( ',', $options['qr_code_background_rgb'] );
+
+		// It might be possible to pass RGBA as well...check class to be sure
+		// https://stackoverflow.com/a/40764343/4484799
+		$fr = $qr_code_foreground_rgb[0];
+		$fg = $qr_code_foreground_rgb[1];
+		$fb = $qr_code_foreground_rgb[2];
+
+		$br = $qr_code_background_rgb[0];
+		$bg = $qr_code_background_rgb[1];
+		$bb = $qr_code_background_rgb[2];
+
+		$writer = new PngWriter();
+
+		$qr_code_label = __( 'Delivery Location', 'lpac' );
+		$qr_code_label = apply_filters( 'lpac_map_location_link_button_text', $qr_code_label );
+
+		/*
+		* Create QR Code
+		*/
+		$qrCode = QrCode::create( $qr_code_data )
+			->setEncoding( new Encoding( 'UTF-8' ) )
+			->setErrorCorrectionLevel( new ErrorCorrectionLevelLow() )
+			->setSize( 200 )
+			->setMargin( 10 )
+			->setRoundBlockSizeMode( new RoundBlockSizeModeMargin() )
+			->setForegroundColor( new Color( $fr, $fg, $fb ) )
+			->setBackgroundColor( new Color( $br, $bg, $bb ) );
+
+		$label = Label::create( $qr_code_label )
+		->setFont( new NotoSans( 18 ) );
+
+		$result = $writer->write( $qrCode, null, $label );
+
+		$image = $result->saveToFile( $path_with_filename );
+
+		// Doesn't work in email clients like Gmail
+		// $image_base64 = $result->getDataUri();
+
+		// return $image_base64;
+
+	}
+
+	/**
+	 * Creates a QR code
+	 *
+	 * @since    1.1.0
+	 */
+	public static function lpac_qr_codes_directory() {
+
+		$upload_dir   = wp_upload_dir();
+		$qr_codes_dir = '';
+
+		if ( ! empty( $upload_dir['basedir'] ) ) {
+
+			$qr_codes_dir = $upload_dir['basedir'] . '/' . 'lpac-qr-codes' . '/' . date( 'Y' ) . '/' . date( 'm' ) . '/' . date( 'd' ) . '/';
+
+			if ( ! file_exists( $qr_codes_dir ) ) {
+				wp_mkdir_p( $qr_codes_dir );
+			}
+
+			return apply_filters( 'lpac_qrcodes_path', $qr_codes_dir );
+		}
+
+		return $qr_codes_dir;
+
+	}
+
+}

--- a/includes/public/js/lpac-public.js
+++ b/includes/public/js/lpac-public.js
@@ -29,9 +29,10 @@
 	 * practising this, we should strive to set a better example in our own work.
 	 */
 
-	 $(document).ready(function(){
+	$( document ).ready(
+		function(){
 
-
-	  });
+		}
+	);
 
 })( jQuery );

--- a/includes/public/js/maps/base-map.js
+++ b/includes/public/js/maps/base-map.js
@@ -1,7 +1,7 @@
-// Google Maps ID
-	var map_id = '';
-if ( map_options.lpac_map_saved_map_id ) {
-	map_id = map_options.lpac_map_saved_map_id;
+var map_id = '';
+
+if ( typeof lpac_pro_js !== 'undefined' ) {
+	map_id = lpac_pro_js.map_id;
 }
 
 	const map = new google.maps.Map(

--- a/includes/public/js/maps/checkout-page-map.js
+++ b/includes/public/js/maps/checkout-page-map.js
@@ -1,9 +1,8 @@
-map.setOptions({
-
-// Overwrite map options
-// https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions
-
-})
+// map.setOptions({
+//    disableDefaultUI: true,
+//  Overwrite map options
+//  https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions
+// })
 
 const geocoder   = new google.maps.Geocoder()
 const infowindow = new google.maps.InfoWindow()
@@ -34,7 +33,7 @@ function get_coordinates() {
 
         if( error.code === 1 ){
             // TODO add input fields so users can change this text
-            alert("You have disabled our website from receiving your location. Click on the location icon in the address bar and allow our website to detect your location.");
+            alert("Something went wrong while trying to detect your location. Click on the location icon in the address bar and allow our website to detect your location. Please contact us if you need additional assistance.");
             return
         }
 
@@ -62,7 +61,7 @@ function get_coordinates() {
 	const position = await this.get_coordinates()
 
     if( ! position ){
-        console.log('Location Picker At Checkout Plugin: Position object is empty. Navigator might be disabled.')
+        console.log('Location Picker At Checkout Plugin: Position object is empty. Navigator might be disabled or this site might be detected as insecure.')
         return;
     }
 

--- a/lpac.php
+++ b/lpac.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Location Picker At Checkout For WooCommerce
  * Plugin URI:        https://soaringleads.com
  * Description:       Allow customers to choose their shipping location using a map at checkout.
- * Version:           1.0.1
+ * Version:           1.1.0
  * Author:            Uriahs Victor
  * Author URI:        https://uriahsvictor.com
  * License:           GPL-2.0+
@@ -24,49 +24,97 @@
  * Text Domain:       lpac
  * Domain Path:       /languages
  * WC requires at least: 3.0
- * WC tested up to: 5.3
+ * WC tested up to: 5.4
  */
-
 // If this file is called directly, abort.
-if ( ! defined( 'WPINC' ) ) {
-	die;
+if ( !defined( 'WPINC' ) ) {
+    die;
 }
 
+if ( !function_exists( 'lpac_fs' ) ) {
+    // Create a helper function for easy SDK access.
+    function lpac_fs()
+    {
+        global  $lpac_fs ;
+        
+        if ( !isset( $lpac_fs ) ) {
+            // Include Freemius SDK.
+            require_once dirname( __FILE__ ) . '/vendor/freemius/wordpress-sdk/start.php';
+            $lpac_fs = fs_dynamic_init( array(
+                'id'             => '8507',
+                'slug'           => 'map-location-picker-at-checkout-for-woocommerce',
+                'type'           => 'plugin',
+                'public_key'     => 'pk_da07de47a2bdd9391af9020cc646d',
+                'is_premium'     => false,
+                'premium_suffix' => 'Pro',
+                'has_addons'     => false,
+                'has_paid_plans' => true,
+                'menu'           => array(
+                'first-path' => 'plugins.php',
+            ),
+                'is_live'        => true,
+            ) );
+        }
+        
+        return $lpac_fs;
+    }
+    
+    // Init Freemius.
+    lpac_fs();
+    // Signal that SDK was initiated.
+    do_action( 'lpac_fs_loaded' );
+}
+
+require dirname( __FILE__ ) . '/vendor/autoload.php';
+include __DIR__ . '/class-lpac-uninstall.php';
+if ( function_exists( 'lpac_fs' ) ) {
+    lpac_fs()->add_action( 'after_uninstall', array( new Lpac_Uninstall(), 'remove_plugin_settings' ) );
+}
 /**
  * Currently plugin version.
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'LPAC_VERSION', '1.0.1' );
+define( 'LPAC_VERSION', '1.1.0' );
 define( 'LPAC_PLUGIN_NAME', 'lpac' );
+define( 'LPAC_PLUGIN_DIR', __DIR__ );
+/**
+ * Create our custom WooCommerce settings tab and render our settings fields
+ */
+function lpac_create_custom_wc_settings_tab( $settings )
+{
+    $settings[] = (include __DIR__ . '/includes/admin/class-lpac-admin-settings.php');
+    return $settings;
+}
 
+add_action( 'woocommerce_get_settings_pages', 'lpac_create_custom_wc_settings_tab' );
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-lpac-activator.php
  */
-function activate_lpac() {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/class-lpac-activator.php';
-	Lpac_Activator::activate();
+function activate_lpac()
+{
+    require_once plugin_dir_path( __FILE__ ) . 'includes/class-lpac-activator.php';
+    Lpac_Activator::activate();
 }
 
 /**
  * The code that runs during plugin deactivation.
  * This action is documented in includes/class-lpac-deactivator.php
  */
-function deactivate_lpac() {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/class-lpac-deactivator.php';
-	Lpac_Deactivator::deactivate();
+function deactivate_lpac()
+{
+    require_once plugin_dir_path( __FILE__ ) . 'includes/class-lpac-deactivator.php';
+    Lpac_Deactivator::deactivate();
 }
 
 register_activation_hook( __FILE__, 'activate_lpac' );
 register_deactivation_hook( __FILE__, 'deactivate_lpac' );
-
 /**
  * The core plugin class that is used to define internationalization,
  * admin-specific hooks, and public-facing site hooks.
  */
 require plugin_dir_path( __FILE__ ) . 'includes/class-lpac.php';
-
 /**
  * Begins execution of the plugin.
  *
@@ -76,10 +124,10 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-lpac.php';
  *
  * @since    1.0.0
  */
-function run_lpac() {
-
-	$plugin = new Lpac();
-	$plugin->run();
-
+function run_lpac()
+{
+    $plugin = new Lpac();
+    $plugin->run();
 }
+
 run_lpac();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,6 +5,7 @@
     <file>.</file>
 
     <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>dist/*</exclude-pattern>
     <rule ref="WordPress-Core">
     </rule>
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Map Location Picker at Checkout for WooCommerce ===
+=== Location Picker at Checkout for WooCommerce ===
 Contributors: uriahs-victor
 Donate link: https://uriahsvictor.com
 Tags: woocommerce, location picker, map, geolocation, checkout map, delivery map, google map

--- a/readme.txt
+++ b/readme.txt
@@ -54,7 +54,7 @@ Plugin settings are located in WordPress Admin Dashboard->WooCommerce->Shipping-
 
 1. Extract the downloaded zip file and upload the `location-picker-at-checkout-for-woocommerce` folder to the `/wp-content/plugins/` directory
 1. Activate the plugin through the 'Plugins' menu in WordPress
-1. Configure the plugin in WooCommerce->Shipping->Location Picker At Checkout
+1. Configure the plugin in WooCommerce->Settings->Location Picker
 
 == Frequently Asked Questions ==
 
@@ -71,6 +71,15 @@ Ensure that you have setup the plugin with your API key by going to WordPress Da
 5. View Order Map View (Past Order)
 
 == Changelog ==
+
+= 1.1.0 =
+* [New] Option to add a button link or QR Code to the customer's map location in WooCommerce's emails.
+* [New] Option to disable map on checkout and order details pages without disabling the plugin.
+* [Fix] Customers were able to complete checkout without selecting a location on the map.
+* [Change] Moved plugin settings to it's own tab in the WooCommerce Settings.
+* [Info] Show admin notice if WooCommerce is not active or the site is not running HTTPS.
+* [Info] Added admin notices if WooCommerce not active or site not running HTTPS.
+* [Info] Tested on WC 5.4.
 
 = 1.0.1 =
 * [New] Automatically fill in address fields with information pulled from Google Maps.


### PR DESCRIPTION
* [New] Option to add a button link or QR Code to the customer's map location in WooCommerce's emails.
* [New] Option to disable map on checkout and order details pages without disabling the plugin.
* [Fix] Customers were able to complete checkout without selecting a location on the map.
* [Change] Moved plugin settings to it's own tab in the WooCommerce Settings.
* [Info] Show admin notice if WooCommerce is not active or the site is not running HTTPS.
* [Info] Added admin notices if WooCommerce not active or site not running HTTPS.
* [Info] Tested on WC 5.4.