### PR TITLE
chore: sync

### DIFF
--- a/class-lpac-uninstall.php
+++ b/class-lpac-uninstall.php
@@ -42,6 +42,7 @@ class Lpac_Uninstall {
 		$option_keys = array(
 			'lpac_enabled',
 			'lpac_google_maps_api_key',
+			'lpac_force_map_use',
 			'lpac_map_starting_coordinates',
 			'lpac_general_map_zoom_level',
 			'lpac_allow_clicking_on_map_icons',

--- a/includes/admin/class-lpac-admin-display.php
+++ b/includes/admin/class-lpac-admin-display.php
@@ -11,7 +11,7 @@
  * @package    Lpac
  * @subpackage Lpac/admin/partials
  */
-class Lpac_Admin_Display {
+class Lpac_Admin_Display extends Lpac_Admin {
 
 	/**
 	 * Displays the view on map button on the admin order page.
@@ -21,11 +21,20 @@ class Lpac_Admin_Display {
 	 */
 	public function lpac_display_lpac_admin_order_meta( $order ) {
 
+		$latitude  = get_post_meta( $order->get_id(), '_lpac_latitude', true );
+		$longitude = get_post_meta( $order->get_id(), '_lpac_longitude', true );
+
+		/**
+		 * If we have no values for these options bail.
+		 */
+		if ( empty( $latitude ) || empty( $longitude ) ) {
+			return;
+		}
+
 		$order_meta_text  = __( 'Customer Location', 'lpac' );
 		$view_on_map_text = __( 'View on Map', 'lpac' );
-		$latitude         = get_post_meta( $order->get_id(), '_lpac_latitude', true );
-		$longitude        = get_post_meta( $order->get_id(), '_lpac_longitude', true );
-		$map_link         = apply_filters( 'lpac_map_provider', "https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}", $latitude, $longitude );
+
+		$map_link = apply_filters( 'lpac_map_provider', "https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}", $latitude, $longitude );
 
 		$markup = <<<LOCATIONMETA
 	<p><strong>$order_meta_text:</strong></p>
@@ -33,6 +42,60 @@ class Lpac_Admin_Display {
 LOCATIONMETA;
 
 		echo $markup;
+	}
+
+	/**
+	 * Create the metabox for holding the map view in admin order details.
+	 *
+	 * @since    1.1.2
+	 */
+	public function lpac_create_custom_order_details_metabox() {
+
+		$latitude  = (float) get_post_meta( get_the_ID(), '_lpac_latitude', true );
+		$longitude = (float) get_post_meta( get_the_ID(), '_lpac_longitude', true );
+
+		/**
+		 * If we have no values for these options bail.
+		 */
+		if ( empty( $latitude ) || empty( $longitude ) ) {
+			return;
+		}
+
+		add_meta_box( 'lpac_delivery_map_metabox', __( 'Delivery Location', 'lpac' ), array( $this, 'lpac_output_custom_order_details_metabox' ), 'shop_order', 'normal', 'high' );
+	}
+
+	/**
+	 * Outputs the HTML for the metabox
+	 *
+	 * @since    1.1.2
+	 */
+	public function lpac_output_custom_order_details_metabox() {
+
+		$latitude  = (float) get_post_meta( get_the_ID(), '_lpac_latitude', true );
+		$longitude = (float) get_post_meta( get_the_ID(), '_lpac_longitude', true );
+
+		$order_coordinates = array(
+			'latitude'  => $latitude,
+			'longitude' => $longitude,
+		);
+
+		$order_coordinates = json_encode( $order_coordinates );
+
+		$global_variables = <<<GLOBALVARS
+	// LPAC Order delivery coordinates
+	var coordinates = $order_coordinates;
+GLOBALVARS;
+
+		wp_add_inline_script( LPAC_PLUGIN_NAME . '-order-map', $global_variables, 'before' );
+
+		$map_container = <<<DIV
+			<div id="wrap" style="display: block; text-align: center;">
+			<div id="lpac-map" style="display: inline-block; padding 10; border: 1px solid #eee; width: 100%; height:345px;"></div>
+			</div>
+DIV;
+
+		echo $map_container;
+
 	}
 
 }

--- a/includes/admin/class-lpac-admin-settings.php
+++ b/includes/admin/class-lpac-admin-settings.php
@@ -104,7 +104,7 @@ class Lpac_Admin_Settings extends WC_Settings_Page
                 'name' => __( 'LPAC General Settings', 'lpac' ),
                 'id'   => 'lpac',
                 'type' => 'title',
-                'desc' => __( 'Use the below options to change the general plugin settings.', 'lpac' ),
+                'desc' => __( '<div style="background: #fff; border-radius: 5px; margin-bottom: 20px; padding: 30px; text-align:center;">Use the options below to change the plugin\'s general settings. <br><br> <strong><span style="font-size: 18px;">If you encounter any issues then please open a support ticket <a href="https://wordpress.org/support/plugin/map-location-picker-at-checkout-for-woocommerce/" target="_blank">HERE <span style="text-decoration: none" class="dashicons dashicons-external"></span></a></span></strong> <br><br> <strong><span style="font-size: 18px;">Plugin settings not in your Language? Help translate it <a href="https://translate.wordpress.org/projects/wp-plugins/map-location-picker-at-checkout-for-woocommerce/" target="_blank">HERE <span style="text-decoration: none" class="dashicons dashicons-external"></span></a></span></strong></div>', 'lpac' ),
             );
             $plugin_enabled = get_option( 'lpac_enabled' );
             /*
@@ -136,10 +136,18 @@ class Lpac_Admin_Settings extends WC_Settings_Page
             $lpac_settings[] = array(
                 'name'     => __( 'Google Maps API Key', 'lpac' ),
                 'desc_tip' => __( 'Enter the API key from Google cloud console.', 'lpac' ),
-                'desc'     => __( 'Enter the API you copied from the Google Cloud Console. <a href="https://github.com/UVLabs/location-picker-at-checkout-for-woocommerce/wiki/Getting-Your-API-Key" target="_blank">Learn More >></a>', 'lpac' ),
+                'desc'     => __( 'Enter the API you copied from the Google Cloud Console. <a href="https://github.com/UVLabs/location-picker-at-checkout-for-woocommerce/wiki/Getting-Your-API-Key" target="_blank">Learn More <span style="text-decoration: none" class="dashicons dashicons-external"></span></a>', 'lpac' ),
                 'id'       => 'lpac_google_maps_api_key',
                 'type'     => 'text',
                 'css'      => 'min-width:300px;',
+            );
+            $lpac_settings[] = array(
+                'name'     => __( 'Force Use of Map', 'lpac' ),
+                'desc'     => __( 'Yes', 'lpac' ),
+                'desc_tip' => __( 'Prevent the customer from checking out until they select a location on the map.', 'lpac' ),
+                'id'       => 'lpac_force_map_use',
+                'type'     => 'checkbox',
+                'css'      => 'max-width:80px;',
             );
             $lpac_settings[] = array(
                 'name'        => __( 'Default Coordinates', 'lpac' ),
@@ -299,7 +307,7 @@ class Lpac_Admin_Settings extends WC_Settings_Page
             );
             $lpac_settings[] = array(
                 'name'    => __( 'Select Emails', 'lpac' ),
-                'class'   => 'select2',
+                'class'   => 'wc-enhanced-select',
                 'desc'    => __( 'Select the Emails you\'d like this setting to take effect on.', 'lpac' ),
                 'id'      => 'lpac_email_delivery_map_emails',
                 'type'    => 'multiselect',

--- a/includes/admin/class-lpac-admin.php
+++ b/includes/admin/class-lpac-admin.php
@@ -32,16 +32,27 @@ class Lpac_Admin {
 	private $version;
 
 	/**
+	 * The full google maps resource with all needed params
+	 *
+	 * @since    1.1.2
+	 * @access   private
+	 * @var      string    $lpac_google_maps_resource   The google maps url.
+	 */
+	private $lpac_google_maps_resource;
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
 	 * @param      string    $plugin_name       The name of this plugin.
 	 * @param      string    $version    The version of this plugin.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct() {
 
-		$this->plugin_name = $plugin_name;
-		$this->version     = $version;
+		$this->plugin_name = LPAC_PLUGIN_NAME;
+		$this->version     = LPAC_VERSION;
+
+		$this->lpac_google_maps_resource = LPAC_GOOGLE_MAPS_LINK . LPAC_GOOGLE_MAPS_API_KEY . LPAC_GOOGLE_MAPS_PARAMS;
 
 	}
 
@@ -88,6 +99,19 @@ class Lpac_Admin {
 		 */
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/lpac-admin.js', array( 'jquery' ), $this->version, false );
+
+		/**
+		 * Enqueue Google Maps script
+		 */
+		wp_enqueue_script( $this->plugin_name . '-google-maps-js', $this->lpac_google_maps_resource, array(), $this->version, false );
+
+		/**
+		 * This has to be enqueued in the footer so our wp_add_inline_script() function can work.
+		 * Only run this code on shop order(order details) page.
+		 */
+		if( get_current_screen()->id === 'shop_order'){
+			wp_enqueue_script( $this->plugin_name . '-order-map', plugin_dir_url( __FILE__ ) . 'js/order-map.js', array( $this->plugin_name . '-google-maps-js' ), $this->version, true );
+		}
 
 	}
 

--- a/includes/admin/js/order-map.js
+++ b/includes/admin/js/order-map.js
@@ -1,0 +1,30 @@
+	var map_id = '';
+
+	if ( typeof lpac_pro_js !== 'undefined' ) {
+		map_id = lpac_pro_js.map_id;
+	}
+
+	const map = new google.maps.Map(
+		document.querySelector( "#lpac-map" ),
+		{
+			center: { lat: coordinates.latitude, lng: coordinates.longitude },
+			zoom: 16,
+			streetViewControl: false,
+			clickableIcons: false,
+			backgroundColor: '#eee', //loading background color
+			mapId: map_id,
+		}
+	);
+
+	const latlng = {
+		lat: coordinates.latitude,
+		lng: coordinates.longitude,
+	};
+
+	const marker = new google.maps.Marker(
+		{
+			position: latlng,
+			map: map,
+			cursor: 'default'
+			}
+	);

--- a/includes/class-lpac.php
+++ b/includes/class-lpac.php
@@ -166,7 +166,7 @@ class Lpac
      */
     private function define_admin_hooks()
     {
-        $plugin_admin = new Lpac_Admin( $this->get_plugin_name(), $this->get_version() );
+        $plugin_admin = new Lpac_Admin();
         $plugin_admin_display = new Lpac_Admin_Display();
         $admin_notices = new Lpac_Admin_Notices();
         $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
@@ -182,6 +182,7 @@ class Lpac
             10,
             1
         );
+        $this->loader->add_action( 'add_meta_boxes', $plugin_admin_display, 'lpac_create_custom_order_details_metabox' );
     }
     
     /**
@@ -245,8 +246,8 @@ class Lpac
         /*
          * Validate latitude and longitude fields.
          */
-        $validate_lat_long_fields = apply_filters( 'validate_lat_long_fields', true );
-        if ( $validate_lat_long_fields ) {
+        $validate_lat_long_fields = get_option( 'lpac_force_map_use', false );
+        if ( $validate_lat_long_fields === 'yes' ) {
             $this->loader->add_action(
                 'woocommerce_after_checkout_validation',
                 $plugin_public_display,

--- a/includes/public/class-lpac-public.php
+++ b/includes/public/class-lpac-public.php
@@ -78,6 +78,7 @@ class Lpac_Public {
 		$this->plugin_name = LPAC_PLUGIN_NAME;
 		$this->version     = LPAC_VERSION;
 
+		// TODO change to use constants set in lpac.php
 		$this->lpac_google_maps_link = 'https://maps.googleapis.com/maps/api/js?key=';
 		$this->lpac_google_api_key   = get_option( 'lpac_google_maps_api_key' );
 
@@ -145,7 +146,6 @@ class Lpac_Public {
 			}
 
 			// Map CDN resource will always load on checkout page since this is the basic functionality of the plugin.
-
 			$lpac_google_maps_resource = $this->lpac_google_maps_link . $this->lpac_google_api_key . $this->lpac_google_maps_params;
 			wp_enqueue_script( LPAC_PLUGIN_NAME . '-google-maps-js', $lpac_google_maps_resource, array(), LPAC_VERSION, false );
 
@@ -163,7 +163,6 @@ class Lpac_Public {
 			}
 
 			// Map resources will always load on checkout page since this is the basic functionality of the plugin.
-
 			wp_enqueue_script( $this->plugin_name . '-base-map', plugin_dir_url( __FILE__ ) . 'js/maps/base-map.js', '', $this->version, true );
 
 			if ( is_wc_endpoint_url( 'order-received' ) ) {
@@ -177,6 +176,9 @@ class Lpac_Public {
 		if ( is_checkout() && ! is_wc_endpoint_url( 'order-received' ) ) {
 
 			wp_enqueue_script( $this->plugin_name . '-base-map', plugin_dir_url( __FILE__ ) . 'js/maps/base-map.js', array( $this->plugin_name . '-google-maps-js' ), $this->version, true );
+			/**
+			 * This has to be enqueued in the footer so our wp_add_inline_script() function can work.
+			 */
 			wp_enqueue_script( $this->plugin_name . '-checkout-page-map', plugin_dir_url( __FILE__ ) . 'js/maps/checkout-page-map.js', array( $this->plugin_name . '-base-map' ), $this->version, true );
 
 		}

--- a/lpac.php
+++ b/lpac.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Location Picker At Checkout For WooCommerce
  * Plugin URI:        https://soaringleads.com
  * Description:       Allow customers to choose their shipping location using a map at checkout.
- * Version:           1.1.1
+ * Version:           1.1.2
  * Author:            Uriahs Victor
  * Author URI:        https://uriahsvictor.com
  * License:           GPL-2.0+
@@ -75,9 +75,13 @@ if ( function_exists( 'lpac_fs' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'LPAC_VERSION', '1.1.1' );
+define( 'LPAC_VERSION', '1.1.2' );
 define( 'LPAC_PLUGIN_NAME', 'lpac' );
 define( 'LPAC_PLUGIN_DIR', __DIR__ );
+define( 'LPAC_GOOGLE_MAPS_LINK', 'https://maps.googleapis.com/maps/api/js?key=' );
+define( 'LPAC_GOOGLE_MAPS_API_KEY', get_option( 'lpac_google_maps_api_key', '' ) );
+$site_locale = get_locale();
+define( 'LPAC_GOOGLE_MAPS_PARAMS', "&language={$site_locale}&libraries=&v=weekly" );
 /**
  * Create our custom WooCommerce settings tab and render our settings fields
  */

--- a/readme.txt
+++ b/readme.txt
@@ -70,8 +70,17 @@ Ensure that you have setup the plugin with your API key by going to WordPress Da
 3. Checkout Page Map View (User selected their location)
 4. Order Received 
 5. View Order Map View (Past Order)
+6. Map view of the customer delivery location on shop order page (in the WordPress dashboard)
 
 == Changelog ==
+
+= 1.1.2 =
+* [New] Option added to allow admin to force customers to select their location on the map before being able to complete the order.
+* [New] Customers can now move the map marker by clicking on the map. This was only possibly by dragging the map marker before.
+* [New] A map view of the customer's location will now appear on the shop order page in WooCommerce->Orders->View.
+* [Change] Order emails multiselect option now uses selectWoo.
+* [Info] Added links to support forum and plugin translation pages to the plugin settings page.
+* [Improvement] Refactored code that handles the checkout page map.
 
 = 1.1.1 =
 * [Fix] Plugin now works with customized checkout fields.


### PR DESCRIPTION
* [New] Option added to allow admin to force customers to select their location on the map before being able to complete the order.
* [New] Customers can now move the map marker by clicking on the map. This was only possibly by dragging the map marker before.
* [New] A map view of the customer's location will now appear on the shop order page in WooCommerce->Orders->View.
* [Change] Order emails multiselect option now uses selectWoo.
* [Info] Added links to support forum and plugin translation pages to the plugin settings page.
* [Improvement] Refactored code that handles the checkout page map.