### PR TITLE
chore: syncing

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run format
+composer run format

--- a/assets/admin/js/order-map.js
+++ b/assets/admin/js/order-map.js
@@ -1,4 +1,5 @@
 function lpacSetupShopOrderMap() {
+  /** These values are coming from the base-map.js enqueued from our maps folder */
   const map = window.lpac_map;
   const marker = window.lpac_marker;
   const infowindow = window.lpac_infowindow;

--- a/includes/Controllers/Emails_Controller.php
+++ b/includes/Controllers/Emails_Controller.php
@@ -113,7 +113,7 @@ HTML;
 		/*
 		* https://example.com/wp-content/uploads/lpac/qr-codes/order_id.jpg
 		*/
-		$qr_code_link           = $this->get_resource_url( $folder_name, $order_id, '.jpg' );
+		$qr_code_link           = $this->get_resource_url( $folder_name, $order_id );
 		$delivery_location_text = __( 'Delivery Location', 'map-location-picker-at-checkout-for-woocommerce' );
 		$delivery_location_text = apply_filters( 'lpac_email_map_location_link_button_text', $delivery_location_text );
 
@@ -166,7 +166,7 @@ HTML;
 			return;
 		}
 
-		$image_src = $this->get_resource_url( $folder_name, $order_id, '.jpg' );
+		$image_src = $this->get_resource_url( $folder_name, $order_id );
 
 		$width  = '';
 		$height = '';

--- a/includes/Notices/Notice.php
+++ b/includes/Notices/Notice.php
@@ -64,8 +64,12 @@ class Notice {
 
 		$dismissed_notices = $this->get_dismissed_notices();
 
+		if ( ! is_array( $dismissed_notices ) ) {
+			return; // Bail if received value type is unexpected.
+		}
+
 		# Bail if this notice has been dismissed
-		if ( in_array( $notice_id, $dismissed_notices ) ) {
+		if ( in_array( $notice_id, $dismissed_notices, true ) ) {
 			return;
 		}
 

--- a/includes/Traits/Upload_Folders.php
+++ b/includes/Traits/Upload_Folders.php
@@ -62,7 +62,7 @@ trait Upload_Folders {
 	 * @param string $ext
 	 * @return string The upload URL
 	 */
-	private function get_resource_url( string $folder_name, int $order_id, string $ext ) {
+	private function get_resource_url( string $folder_name, int $order_id, string $ext = '.jpg' ) {
 
 		$upload_url = wp_upload_dir()['baseurl'];
 

--- a/lpac.php
+++ b/lpac.php
@@ -17,7 +17,7 @@
  * Plugin Name:       Location Picker At Checkout For WooCommerce
  * Plugin URI:        https://lpacwp.com
  * Description:       Allow customers to choose their shipping location using a map at checkout.
- * Version:           1.4.3-lite
+ * Version:           1.4.4-lite
  * Author:            Uriahs Victor
  * Author URI:        https://uriahsvictor.com
  * License:           GPL-2.0+
@@ -33,7 +33,7 @@ if ( !defined( 'WPINC' ) ) {
     die;
 }
 if ( !defined( 'LPAC_VERSION' ) ) {
-    define( 'LPAC_VERSION', '1.4.3' );
+    define( 'LPAC_VERSION', '1.4.4' );
 }
 /**
  * The code that runs during plugin activation.

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://uriahsvictor.com
 Tags: woocommerce, location picker, checkout map, geolocation, google map, map, delivery map
 Requires at least: 5.5
 Requires PHP: 7.0
-Tested up to: 5.8
-Stable tag: 1.4.3
+Tested up to: 5.9
+Stable tag: 1.4.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -163,6 +163,10 @@ Post it on the [support forum](https://wordpress.org/support/plugin/map-location
 The save location of QR codes have been changed. Links to QR codes in past order emails will stop working after updating, but QR codes in new orders will work fine.
 
 == Changelog ==
+
+= 1.4.4 =
+* [Fix] Error caused when dismissed notices returns a string.
+* [Info] Tested on WP 5.9
 
 = 1.4.3 =
 * [New PRO] Option to change the type of results returned by the Places Autocomplete API (Geocode, Address, Establishment, Regions, Cities)


### PR DESCRIPTION
[Fix] Error caused when dismissed notices returns a string.
[Info] Tested on WP 5.9