### PR TITLE
chore: syncing

### DIFF
--- a/assets/public/js/maps/checkout-page-map.js
+++ b/assets/public/js/maps/checkout-page-map.js
@@ -722,6 +722,13 @@ function lpacSetLastOrderMarker() {
  * @returns
  */
 function addPlacesAutoComplete() {
+  if (typeof mapOptions === "undefined" || mapOptions === null) {
+    console.log(
+      "LPAC: mapOptions object not present. This shouldn't be happening here. Contact Support."
+    );
+    return;
+  }
+
   // Return if feature not enabled
   if (!mapOptions.lpac_enable_places_autocomplete) {
     return;

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "wp-coding-standards/wpcs": "2.3"
     },
     "require": {
-        "freemius/wordpress-sdk": "2.4.2",
+        "freemius/wordpress-sdk": "2.4.3",
         "endroid/qr-code": "4.3.5"
     },
     "autoload":{

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0982f709642a1ed8a7b7ba0de5689423",
+    "content-hash": "d15d072b629cfbbf862e41c6af76ce47",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
-            "version": "2.0.4",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Bacon/BaconQrCode.git",
-                "reference": "f73543ac4e1def05f1a70bcd1525c8a157a1ad09"
+                "reference": "0069435e2a01a57193b25790f105a5d3168653c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/f73543ac4e1def05f1a70bcd1525c8a157a1ad09",
-                "reference": "f73543ac4e1def05f1a70bcd1525c8a157a1ad09",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/0069435e2a01a57193b25790f105a5d3168653c1",
+                "reference": "0069435e2a01a57193b25790f105a5d3168653c1",
                 "shasum": ""
             },
             "require": {
@@ -26,8 +26,9 @@
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phly/keep-a-changelog": "^1.4",
+                "phly/keep-a-changelog": "^2.1",
                 "phpunit/phpunit": "^7 | ^8 | ^9",
+                "spatie/phpunit-snapshot-assertions": "^4.2.9",
                 "squizlabs/php_codesniffer": "^3.4"
             },
             "suggest": {
@@ -55,9 +56,9 @@
             "homepage": "https://github.com/Bacon/BaconQrCode",
             "support": {
                 "issues": "https://github.com/Bacon/BaconQrCode/issues",
-                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.4"
+                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.6"
             },
-            "time": "2021-06-18T13:26:35+00:00"
+            "time": "2022-02-04T20:16:05+00:00"
         },
         {
             "name": "dasprid/enum",
@@ -180,16 +181,16 @@
         },
         {
             "name": "freemius/wordpress-sdk",
-            "version": "2.4.2",
+            "version": "2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Freemius/wordpress-sdk.git",
-                "reference": "84a9be4717effd7697a217e0d931f48ae0d2ecc6"
+                "reference": "d2c3e1c27792f34123f928ea9fa73be56c337d13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Freemius/wordpress-sdk/zipball/84a9be4717effd7697a217e0d931f48ae0d2ecc6",
-                "reference": "84a9be4717effd7697a217e0d931f48ae0d2ecc6",
+                "url": "https://api.github.com/repos/Freemius/wordpress-sdk/zipball/d2c3e1c27792f34123f928ea9fa73be56c337d13",
+                "reference": "d2c3e1c27792f34123f928ea9fa73be56c337d13",
                 "shasum": ""
             },
             "require": {
@@ -213,9 +214,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Freemius/wordpress-sdk/issues",
-                "source": "https://github.com/Freemius/wordpress-sdk/tree/2.4.2"
+                "source": "https://github.com/Freemius/wordpress-sdk/tree/2.4.3"
             },
-            "time": "2021-02-08T16:47:44+00:00"
+            "time": "2022-03-03T09:14:17+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/Views/Frontend.php
+++ b/includes/Views/Frontend.php
@@ -112,7 +112,12 @@ HTML;
 
 		// Add inline global JS so that we can use data fetched using PHP inside JS
 		$global_js_vars = $this->setup_global_js_vars();
-		wp_add_inline_script( LPAC_PLUGIN_NAME . '-base-map', $global_js_vars, 'before' );
+
+		$added = wp_add_inline_script( LPAC_PLUGIN_NAME . '-base-map', $global_js_vars, 'before' );
+		// On some websites our basemap might not enqueue in time. In those cases fall back to default wp jquery handle.
+		if ( empty( $added ) ) {
+			wp_add_inline_script( 'jquery-core', $global_js_vars, 'before' );
+		}
 
 	}
 
@@ -179,7 +184,12 @@ HTML;
 
 		// Add inline global JS so that we can use data fetched using PHP inside JS
 		$global_js_vars = $this->setup_global_js_vars( $user_location_collected_during_order );
-		wp_add_inline_script( LPAC_PLUGIN_NAME . '-base-map', $global_js_vars, 'before' );
+
+		$added = wp_add_inline_script( LPAC_PLUGIN_NAME . '-base-map', $global_js_vars, 'before' );
+		// On some websites our basemap might not enqueue in time. In those cases fall back to default wp jquery handle.
+		if ( empty( $added ) ) {
+			wp_add_inline_script( 'jquery-core', $global_js_vars, 'before' );
+		}
 
 	}
 

--- a/lpac.php
+++ b/lpac.php
@@ -17,7 +17,7 @@
  * Plugin Name:       Location Picker At Checkout For WooCommerce
  * Plugin URI:        https://lpacwp.com
  * Description:       Allow customers to choose their shipping location using a map at checkout.
- * Version:           1.4.4-lite
+ * Version:           1.4.5-lite
  * Author:            Uriahs Victor
  * Author URI:        https://uriahsvictor.com
  * License:           GPL-2.0+
@@ -26,14 +26,14 @@
  * Domain Path:       /languages
  * WC requires at least: 3.0
  * WC tested up to: 6.0
- * Requires PHP: 7.0
+ * Requires PHP: 7.3
  */
 // If this file is called directly, abort.
 if ( !defined( 'WPINC' ) ) {
     die;
 }
 if ( !defined( 'LPAC_VERSION' ) ) {
-    define( 'LPAC_VERSION', '1.4.4' );
+    define( 'LPAC_VERSION', '1.4.5' );
 }
 /**
  * The code that runs during plugin activation.
@@ -157,7 +157,7 @@ if ( !in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', 
  */
 if ( function_exists( 'phpversion' ) ) {
     
-    if ( version_compare( phpversion(), '7.0', '<' ) ) {
+    if ( version_compare( phpversion(), '7.3', '<' ) ) {
         add_action( 'admin_notices', array( new Lpac\Notices\Admin(), 'output_php_version_notice' ) );
         return;
     }
@@ -168,7 +168,7 @@ if ( function_exists( 'phpversion' ) ) {
  */
 if ( defined( 'PHP_VERSION' ) ) {
     
-    if ( version_compare( PHP_VERSION, '7.0', '<' ) ) {
+    if ( version_compare( PHP_VERSION, '7.3', '<' ) ) {
         add_action( 'admin_notices', array( new Lpac\Notices\Admin(), 'output_php_version_notice' ) );
         return;
     }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: uriahs-victor
 Donate link: https://uriahsvictor.com
 Tags: woocommerce, location picker, checkout map, geolocation, google map, map, delivery map
 Requires at least: 5.5
-Requires PHP: 7.0
+Requires PHP: 7.3
 Tested up to: 5.9
 Stable tag: 1.4.4
 License: GPLv2 or later
@@ -163,6 +163,10 @@ Post it on the [support forum](https://wordpress.org/support/plugin/map-location
 The save location of QR codes have been changed. Links to QR codes in past order emails will stop working after updating, but QR codes in new orders will work fine.
 
 == Changelog ==
+
+= 1.4.5 =
+* [Fix] The frontend maps required base script file would on some websites not be enqueued in time to be used as a handle for `wp_add_inline_script()` function . Fallback to Jquery core script handle in those cases.
+* [Change] Set minimum required PHP version to 7.3
 
 = 1.4.4 =
 * [Fix] Error caused when dismissed notices returns a string.


### PR DESCRIPTION
* [Fix] The frontend maps required base script file would on some websites not be enqueued in time to be used as a handle for `wp_add_inline_script()` function . Fallback to Jquery core script handle in those cases.
* [Change] Set minimum required PHP version to 7.3